### PR TITLE
Adds official Mac client support

### DIFF
--- a/launcher.py
+++ b/launcher.py
@@ -18,7 +18,7 @@ else:
 	from ConfigParser import ConfigParser
 
 def gen_launcher_command(settings):
-	exe_path=settings['path']
+	exe_path=get_ffxiv_path(settings)
 
 	if(settings['use_dx11'].strip() == 'True'):
 		exe_path = join_path(exe_path,'game/ffxiv_dx11.exe')
@@ -36,15 +36,30 @@ def gen_launcher_command(settings):
 		'SYS.Region='+settings['region'],
 		'ver='+settings['version']]
 
+	# Deal with macOS
+	if (settings['mac_app'] != ''):
+		# Truncate the extraneous exe_path from the existing launcher_dict
+		launcher_dict = launcher_dict[1:]
+		# Path to the cider launcher
+		cider_bin = join_path(settings['mac_app'], 'Contents/MacOS/FINALFANTASYXIV')
+		cmdline = ' '.join(launcher_dict)
+		launcher_dict = [cider_bin, '-cmdline', cmdline, exe_path]
+
 	#Deal with pre_command (NOT Running on windows)
 	if settings['pre_command'].strip() != '':
 		launcher_dict.insert(0,settings['pre_command'].strip())
 
 	return launcher_dict
 
+def get_ffxiv_path(settings):
+	if (settings['mac_app'] != ''):
+		return join_path(settings['mac_app'], 'Contents/Resources/transgaming/c_drive/ffxiv/')
+	else:
+		return settings['path']
+
 def run(settings):
 	sid=login(settings['region'],settings['user'],settings['password'],settings['one_time_password'])
-	(settings['actual_sid'],settings['version']) = get_actual_sid(sid,settings['path'])
+	(settings['actual_sid'],settings['version']) = get_actual_sid(sid, get_ffxiv_path(settings))
 	launch = gen_launcher_command(settings)
 	for i in launch:
 		print(i,end=' ')

--- a/launcher_config.ini
+++ b/launcher_config.ini
@@ -8,11 +8,15 @@ expansion_id = 0
 region = 3
 #Use Direct X 11 mode
 use_dx11 = False
-#Path to the game's directory (DON'T use quotes)
+#Path to the game's directory (DON'T use quotes), unused if mac_app is set
 path =
 #Command to run before executing the game
-#Leave blank for windows or MacOS, 'wine' for Linux
-pre_command =
+#Leave blank for windows & macos, and 'wine' for Linux
+pre_command = 
+# For official Mac client users, the path to FINAL FANTASY XIV.app:
+# Usually /Applications/FINAL FANTASY XIV.app (DON'T use quotes)
+# Leave this blank unless you use the official FFXIV Mac client!
+mac_app =
 user =
 password =
 one_time_password =


### PR DESCRIPTION
This adds support for the _official_ Mac client (i.e the one that runs on Cider and is available for purchase from Square Enix), as opposed to the current support which is only for custom wine / wineskin installs.

To do this I added an additional configuration option `mac_app` which is the path to the `FINAL FANTASY XIV.app` bundle, usually (but not guaranteed to be) in `/Applications`. When this config option is present, the Mac behaviour overrides the launch arguments and overrides any `wine_command` set.

I also removed an `exit()` call which was left in and preventing everything from working -- guessing you accidentally left that in while developing and was sick of the game launching all the time? ;)

I'm pull requesting you instead of the original author @mclark4386 because the original author hasn't responded to any PRs lately so I figured working off your much more recent codebase was for the best.